### PR TITLE
fix javascript file name

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,6 +26,6 @@
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis, nisi sed possimus quibusdam reiciendis laudantium adipisci dolores! Amet provident quia repudiandae porro distinctio temporibus iste, totam ea, assumenda soluta corrupti. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Tenetur asperiores laboriosam rem, quos cum quaerat facilis soluta fugit suscipit quidem qui voluptates incidunt minus iusto veniam eius. Ratione, unde veritatis? Lorem ipsum dolor, sit amet consectetur adipisicing elit. Voluptas, officia doloremque veritatis asperiores ipsa corporis consequatur suscipit molestiae amet, incidunt quis quo. Itaque in dolor nulla reiciendis nesciunt quas optio.</p>
         <img class="photography" src="photography.jpg">
     </div>
-    <script src="javascript.html"></script>
+    <script src="javascript.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,6 @@
         <h3>“Winners never quit, and quitters never win.” - Vince Lombardi.</h3>
         <img class="software" src="software.jpg">
     </div>
-    <script src="javascript.html"></script>
+    <script src="javascript.js"></script>
 </body>
 </html>

--- a/portfolio.html
+++ b/portfolio.html
@@ -26,6 +26,6 @@
         <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Asperiores suscipit doloribus deleniti repellendus labore sit eveniet, iusto cupiditate soluta pariatur alias, dolores, assumenda accusamus illo consequatur neque tempore quia quo? Lorem ipsum dolor sit amet consectetur adipisicing elit. Illum voluptas consequatur soluta sit quas tempore vero, perferendis voluptatibus doloremque voluptatum eaque, laboriosam dolorum est possimus aliquam quo nemo consequuntur quibusdam! Lorem ipsum dolor sit amet consectetur adipisicing elit. Quas explicabo nostrum, facere veniam quaerat ratione, dolore quibusdam deserunt obcaecati molestiae rerum incidunt ducimus omnis! Dolore earum expedita esse illum provident?</p>
         <img class="project3" src="project3.webp">
     </div>
-    <script src="javascript.html"></script>    
+    <script src="javascript.js"></script>    
 </body>
 </html>


### PR DESCRIPTION
In my three HTML files, I originally calling the script `javascript.html` but this file doesn't exist. This was a typo I found because the actual script is called `javascript.js`.

I tested that the "Hello World!" which is logged from this script showed up in the Chrome console. Before my fix, this didn't show up because there was an error along the lines of "Failed to load resource".